### PR TITLE
remove .idea folder and convert orgs to lowercase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 Config.json
+.vs/
+.idea/
+TestResults/

--- a/.idea/.idea.SboxDiscordBot/.idea/.gitignore
+++ b/.idea/.idea.SboxDiscordBot/.idea/.gitignore
@@ -1,8 +1,0 @@
-﻿# Default ignored files
-/shelf/
-/workspace.xml
-# Rider ignored files
-/modules.xml
-/contentModel.xml
-/.idea.SboxDiscordBot.iml
-/projectSettingsUpdater.xml

--- a/.idea/.idea.SboxDiscordBot/.idea/encodings.xml
+++ b/.idea/.idea.SboxDiscordBot/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
-</project>

--- a/.idea/.idea.SboxDiscordBot/.idea/indexLayout.xml
+++ b/.idea/.idea.SboxDiscordBot/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/.idea/.idea.SboxDiscordBot/.idea/vcs.xml
+++ b/.idea/.idea.SboxDiscordBot/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/SboxDiscordBot/SboxApi.cs
+++ b/SboxDiscordBot/SboxApi.cs
@@ -24,6 +24,8 @@ namespace SboxDiscordBot
 
         public Promise<Org> GetOrg(string ident)
         {
+            ident = ident.ToLower();
+
             var promise = new Promise<Org>();
             /* Right now, this is a big bodge / hack
              * Here's what we do:


### PR DESCRIPTION
I don't think the .idea folder is needed for anything and converting orgs to lowercase is because the bot says invalid org when you don't use the right capitalization, this fixes that